### PR TITLE
fix install target for boost_python3

### DIFF
--- a/libs/python/build/Jamfile.v2
+++ b/libs/python/build/Jamfile.v2
@@ -141,11 +141,13 @@ rule lib_boost_python ( is-py3 ? )
 
 }
 
-lib_boost_python ;
-boost-install boost_python ;
-
 if $(py3-version)
 {
     lib_boost_python yes ;
     boost-install boost_python3 ;
+}
+else
+{
+    lib_boost_python ;
+    boost-install boost_python ;
 }


### PR DESCRIPTION
fix valid only for 1.62
in upstream this issue is already fixed in a much more heavy way